### PR TITLE
Fixing bugs with report loading and reading products

### DIFF
--- a/modules/Reporting/Reporting/BoldReportsAPIController.cs
+++ b/modules/Reporting/Reporting/BoldReportsAPIController.cs
@@ -46,7 +46,8 @@ public class BoldReportsAPIController : Controller, IReportController
     {
         string basePath = _hostingEnvironment.WebRootPath;
         // Here, we have loaded the sales-order-detail.rdl report from the application folder wwwrootResources. sales-order-detail.rdl should be located in the wwwroot\Resources application folder.
-        System.IO.FileStream inputStream = new System.IO.FileStream(basePath + @"\Resources\" + reportOption.ReportModel.ReportPath + ".rdl", System.IO.FileMode.Open, System.IO.FileAccess.Read);
+        var path = Path.Combine(basePath, "Resources", reportOption.ReportModel.ReportPath + ".rdl");
+        System.IO.FileStream inputStream = new System.IO.FileStream(path, System.IO.FileMode.Open, System.IO.FileAccess.Read);
         MemoryStream reportStream = new MemoryStream();
         inputStream.CopyTo(reportStream);
         reportStream.Position = 0;

--- a/src/OMSBlazor.Application/ApplicationServices/ProductApplicationService.cs
+++ b/src/OMSBlazor.Application/ApplicationServices/ProductApplicationService.cs
@@ -21,17 +21,15 @@ namespace OMSBlazor.Application.ApplicationServices
         private readonly IReadOnlyRepository<Product, int> _productReadOnlyRepository; // AsNoTracking behind the scenes for Get requests 
         private readonly IRepository<ProductsByCategory, int> _productsByCategoryRepository;
         private readonly IProductManager _productManager;
-        private readonly IDistributedCache<List<Product>> _productCache; // added InMemory cache for products
+        private readonly IDistributedCache<List<ProductDto>> _productCache; // added InMemory cache for products
 
         public ProductApplicationService(
             IRepository<Product, int> productRepository,
-            IReadOnlyRepository<Product, int> productReadOnlyRepository,
             IProductManager productManager,
             IRepository<ProductsByCategory, int> productsByCategoryRepository,
-            IDistributedCache<List<Product>> productCache)
+            IDistributedCache<List<ProductDto>> productCache)
         {
             _productRepository = productRepository;
-            _productReadOnlyRepository = productReadOnlyRepository;
             _productManager = productManager;
             _productsByCategoryRepository = productsByCategoryRepository;
             _productCache = productCache;
@@ -45,7 +43,7 @@ namespace OMSBlazor.Application.ApplicationServices
                 async () => 
                 {
                     var list = await _productReadOnlyRepository.ToListAsync();
-                    return list;
+                    return ObjectMapper.Map<List<Product>, List<ProductDto>>(list);
                 },
                 () => new DistributedCacheEntryOptions
                 {
@@ -58,8 +56,8 @@ namespace OMSBlazor.Application.ApplicationServices
             {
                 throw new Exception(OMSBlazorDomainErrorCodes.ProductListIsNull);
             }
-
-            return ObjectMapper.Map<List<Product>, List<ProductDto>>(products);
+            
+            return products;
         }
 
         public async Task<ProductDto> GetProductAsync(int id)


### PR DESCRIPTION
- In the `BoldReportsAPIController` class, in method - `OnInitReportOptions` is used `Path.Combine` for better cross-platform experience
- `IDistributedCache` in `ProductApplicationService` now is type of `ProductDto` rather than `Product`